### PR TITLE
Si70xx / HTU2xD / SHT2x and SCD4X CO2

### DIFF
--- a/components/scd4x/.eil.yml
+++ b/components/scd4x/.eil.yml
@@ -1,0 +1,23 @@
+name: scd4x
+description: Driver for SCD40/SCD41 miniature CO₂ sensor
+version: 1.0.0
+groups:
+  - gas
+  - air-quality
+code_owners: UncleRus
+depends:
+  - i2cdev
+  - log
+  - esp_idf_lib_helpers
+thread_safe: yes
+targets:
+  - esp32
+  - esp8266
+  - esp32s2
+  - esp32c3
+license: BSD-3
+copyrights:
+  - name: UncleRus
+    year: 2021
+  - name: Sensirion
+    year: 2021

--- a/components/scd4x/CMakeLists.txt
+++ b/components/scd4x/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(
+    SRCS scd4x.c
+    INCLUDE_DIRS .
+    REQUIRES i2cdev log esp_idf_lib_helpers
+)

--- a/components/scd4x/LICENSE
+++ b/components/scd4x/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2021, Sensirion AG
+Copyright (c) 2021 Ruslan V. Uss <unclerus@gmail.com>
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of itscontributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/components/scd4x/component.mk
+++ b/components/scd4x/component.mk
@@ -1,0 +1,2 @@
+COMPONENT_ADD_INCLUDEDIRS = .
+COMPONENT_DEPENDS = i2cdev log esp_idf_lib_helpers

--- a/components/scd4x/scd4x.c
+++ b/components/scd4x/scd4x.c
@@ -1,0 +1,365 @@
+/*
+ * Copyright (c) 2021, Sensirion AG
+ * Copyright (c) 2021 Ruslan V. Uss <unclerus@gmail.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of itscontributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file scd4x.c
+ *
+ * ESP-IDF driver for SCD4x CO2 sensor.
+ *
+ * Ported from https://github.com/Sensirion/raspberry-pi-i2c-scd4x
+ *
+ * Copyright (c) 2021, Sensirion AG
+ * Copyright (c) 2021 Ruslan V. Uss <unclerus@gmail.com>
+ *
+ * BSD Licensed as described in the file LICENSE
+ */
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+#include <esp_log.h>
+#include <ets_sys.h>
+#include <esp_idf_lib_helpers.h>
+#include "scd4x.h"
+
+#define I2C_FREQ_HZ 100000 // 100kHz
+
+static const char *TAG = "scd4x";
+
+#define CMD_START_PERIODIC_MEASUREMENT             (0x21B1)
+#define CMD_READ_MEASUREMENT                       (0xEC05)
+#define CMD_STOP_PERIODIC_MEASUREMENT              (0x3F86)
+#define CMD_SET_TEMPERATURE_OFFSET                 (0x241D)
+#define CMD_GET_TEMPERATURE_OFFSET                 (0x2318)
+#define CMD_SET_SENSOR_ALTITUDE                    (0x2427)
+#define CMD_GET_SENSOR_ALTITUDE                    (0x2322)
+#define CMD_SET_AMBIENT_PRESSURE                   (0xE000)
+#define CMD_PERFORM_FORCED_RECALIBRATION           (0x362F)
+#define CMD_SET_AUTOMATIC_SELF_CALIBRATION_ENABLED (0x2416)
+#define CMD_GET_AUTOMATIC_SELF_CALIBRATION_ENABLED (0x2313)
+#define CMD_START_LOW_POWER_PERIODIC_MEASUREMENT   (0x21AC)
+#define CMD_GET_DATA_READY_STATUS                  (0xE4B8)
+#define CMD_PERSIST_SETTINGS                       (0x3615)
+#define CMD_GET_SERIAL_NUMBER                      (0x3682)
+#define CMD_PERFORM_SELF_TEST                      (0x3639)
+#define CMD_PERFORM_FACTORY_RESET                  (0x3632)
+#define CMD_REINIT                                 (0x3646)
+#define CMD_MEASURE_SINGLE_SHOT                    (0x219D)
+#define CMD_MEASURE_SINGLE_SHOT_RHT_ONLY           (0x2196)
+#define CMD_POWER_DOWN                             (0x36E0)
+#define CMD_WAKE_UP                                (0x36F6)
+
+#define CHECK(x) do { esp_err_t __; if ((__ = x) != ESP_OK) return __; } while (0)
+#define CHECK_ARG(VAL) do { if (!(VAL)) return ESP_ERR_INVALID_ARG; } while (0)
+
+static uint8_t crc8(const uint8_t *data, size_t count)
+{
+    uint8_t res = 0xff;
+
+    for (size_t i = 0; i < count; ++i)
+    {
+        res ^= data[i];
+        for (uint8_t bit = 8; bit > 0; --bit)
+        {
+            if (res & 0x80)
+                res = (res << 1) ^ 0x31;
+            else
+                res = (res << 1);
+        }
+    }
+    return res;
+}
+
+static inline uint16_t swap(uint16_t v)
+{
+    return (v << 8) | (v >> 8);
+}
+
+static esp_err_t send_cmd(i2c_dev_t *dev, uint16_t cmd, uint16_t *data, size_t words)
+{
+    uint8_t buf[2 + words * 3];
+    // add command
+    *(uint16_t *)buf = swap(cmd);
+    if (data && words)
+        // add arguments
+        for (size_t i = 0; i < words; i++)
+        {
+            uint8_t *p = buf + 2 + i * 3;
+            *(uint16_t *)p = swap(data[i]);
+            *(p + 2) = crc8(p, 2);
+        }
+
+    ESP_LOGV(TAG, "Sending buffer:");
+    ESP_LOG_BUFFER_HEX_LEVEL(TAG, buf, sizeof(buf), ESP_LOG_VERBOSE);
+
+    return i2c_dev_write(dev, NULL, 0, buf, sizeof(buf));
+}
+
+static esp_err_t read_resp(i2c_dev_t *dev, uint16_t *data, size_t words)
+{
+    uint8_t buf[words * 3];
+    CHECK(i2c_dev_read(dev, NULL, 0, buf, sizeof(buf)));
+
+    ESP_LOGV(TAG, "Received buffer:");
+    ESP_LOG_BUFFER_HEX_LEVEL(TAG, buf, sizeof(buf), ESP_LOG_VERBOSE);
+
+    for (size_t i = 0; i < words; i++)
+    {
+        uint8_t *p = buf + i * 3;
+        uint8_t crc = crc8(p, 2);
+        if (crc != *(p + 2))
+        {
+            ESP_LOGE(TAG, "Invalid CRC 0x%02x, expected 0x%02x", crc, *(p + 2));
+            return ESP_ERR_INVALID_CRC;
+        }
+        data[i] = swap(*(uint16_t *)p);
+    }
+    return ESP_OK;
+}
+
+static esp_err_t execute_cmd(i2c_dev_t *dev, uint16_t cmd, uint32_t timeout_ms,
+        uint16_t *out_data, size_t out_words, uint16_t *in_data, size_t in_words)
+{
+    CHECK_ARG(dev);
+
+    I2C_DEV_TAKE_MUTEX(dev);
+    I2C_DEV_CHECK(dev, send_cmd(dev, cmd, out_data, out_words));
+    if (timeout_ms)
+    {
+        if (timeout_ms > 10)
+            vTaskDelay(pdMS_TO_TICKS(timeout_ms));
+        else
+            ets_delay_us(timeout_ms * 1000);
+    }
+    if (in_data && in_words)
+        I2C_DEV_CHECK(dev, read_resp(dev, in_data, in_words));
+    I2C_DEV_GIVE_MUTEX(dev);
+
+    return ESP_OK;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+esp_err_t scd4x_init_desc(i2c_dev_t *dev, i2c_port_t port, gpio_num_t sda_gpio, gpio_num_t scl_gpio)
+{
+    CHECK_ARG(dev);
+
+    dev->port = port;
+    dev->addr = SCD4X_I2C_ADDR;
+    dev->cfg.sda_io_num = sda_gpio;
+    dev->cfg.scl_io_num = scl_gpio;
+#if HELPER_TARGET_IS_ESP32
+    dev->cfg.master.clk_speed = I2C_FREQ_HZ;
+#endif
+
+    return i2c_dev_create_mutex(dev);
+}
+
+esp_err_t scd4x_free_desc(i2c_dev_t *dev)
+{
+    CHECK_ARG(dev);
+
+    return i2c_dev_delete_mutex(dev);
+}
+
+esp_err_t scd4x_start_periodic_measurement(i2c_dev_t *dev)
+{
+    return execute_cmd(dev, CMD_START_PERIODIC_MEASUREMENT, 1, NULL, 0, NULL, 0);
+}
+
+esp_err_t scd4x_read_measurement_ticks(i2c_dev_t *dev, uint16_t *co2, uint16_t *temperature, uint16_t *humidity)
+{
+    CHECK_ARG(co2 || temperature || humidity);
+
+    uint16_t buf[3];
+    CHECK(execute_cmd(dev, CMD_READ_MEASUREMENT, 1, NULL, 0, buf, 3));
+    if (co2)
+        *co2 = buf[0];
+    if (temperature)
+        *temperature = buf[1];
+    if (humidity)
+        *humidity = buf[2];
+
+    return ESP_OK;
+}
+
+esp_err_t scd4x_read_measurement(i2c_dev_t *dev, uint16_t *co2, float *temperature, float *humidity)
+{
+    CHECK_ARG(co2 || temperature || humidity);
+    uint16_t t_raw, h_raw;
+
+    CHECK(scd4x_read_measurement_ticks(dev, co2, &t_raw, &h_raw));
+    if (temperature)
+        *temperature = (float)t_raw * 175.0f / 65536.0f - 45.0f;
+    if (humidity)
+        *humidity = (float)h_raw * 100.0f / 65536.0f;
+
+    return ESP_OK;
+}
+
+esp_err_t scd4x_stop_periodic_measurement(i2c_dev_t *dev)
+{
+    return execute_cmd(dev, CMD_STOP_PERIODIC_MEASUREMENT, 500, NULL, 0, NULL, 0);
+}
+
+esp_err_t scd4x_get_temperature_offset_ticks(i2c_dev_t *dev, uint16_t *t_offset)
+{
+    CHECK_ARG(t_offset);
+
+    return execute_cmd(dev, CMD_GET_TEMPERATURE_OFFSET, 1, NULL, 0, t_offset, 1);
+}
+
+esp_err_t scd4x_get_temperature_offset(i2c_dev_t *dev, float *t_offset)
+{
+    CHECK_ARG(t_offset);
+    uint16_t raw;
+
+    CHECK(scd4x_get_temperature_offset_ticks(dev, &raw));
+
+    *t_offset = (float)raw * 175.0f / 65536.0f;
+
+    return ESP_OK;
+}
+
+esp_err_t scd4x_set_temperature_offset_ticks(i2c_dev_t *dev, uint16_t t_offset)
+{
+    return execute_cmd(dev, CMD_SET_TEMPERATURE_OFFSET, 1, &t_offset, 1, NULL, 0);
+}
+
+esp_err_t scd4x_set_temperature_offset(i2c_dev_t *dev, float t_offset)
+{
+    uint16_t raw = (uint16_t)(t_offset * 65536.0f / 175.0f + 0.5f);
+    return scd4x_set_temperature_offset_ticks(dev, raw);
+}
+
+esp_err_t scd4x_get_sensor_altitude(i2c_dev_t *dev, uint16_t *altitude)
+{
+    CHECK_ARG(altitude);
+
+    return execute_cmd(dev, CMD_GET_SENSOR_ALTITUDE, 1, NULL, 0, altitude, 1);
+}
+
+esp_err_t scd4x_set_sensor_altitude(i2c_dev_t *dev, uint16_t altitude)
+{
+    return execute_cmd(dev, CMD_SET_SENSOR_ALTITUDE, 1, &altitude, 1, NULL, 0);
+}
+
+esp_err_t scd4x_set_ambient_ressure(i2c_dev_t *dev, uint16_t pressure)
+{
+    return execute_cmd(dev, CMD_SET_AMBIENT_PRESSURE, 1, &pressure, 1, NULL, 0);
+}
+
+esp_err_t scd4x_perform_forced_recalibration(i2c_dev_t *dev, uint16_t target_co2_concentration,
+        uint16_t *frc_correction)
+{
+    CHECK_ARG(frc_correction);
+
+    return execute_cmd(dev, CMD_PERFORM_FORCED_RECALIBRATION, 400,
+            &target_co2_concentration, 1, frc_correction, 1);
+}
+
+esp_err_t scd4x_get_automatic_self_calibration(i2c_dev_t *dev, bool *enabled)
+{
+    CHECK_ARG(enabled);
+
+    return execute_cmd(dev, CMD_GET_AUTOMATIC_SELF_CALIBRATION_ENABLED, 1, NULL, 0, (uint16_t *)enabled, 1);
+}
+
+esp_err_t scd4x_set_automatic_self_calibration(i2c_dev_t *dev, bool enabled)
+{
+    return execute_cmd(dev, CMD_SET_AUTOMATIC_SELF_CALIBRATION_ENABLED, 1, (uint16_t *)&enabled, 1, NULL, 0);
+}
+
+esp_err_t scd4x_start_low_power_periodic_measurement(i2c_dev_t *dev)
+{
+    return execute_cmd(dev, CMD_START_LOW_POWER_PERIODIC_MEASUREMENT, 0, NULL, 0, NULL, 0);
+}
+
+esp_err_t scd4x_get_data_ready_status(i2c_dev_t *dev, bool *data_ready)
+{
+    CHECK_ARG(data_ready);
+
+    uint16_t status;
+    CHECK(execute_cmd(dev, CMD_GET_DATA_READY_STATUS, 1, NULL, 0, &status, 1));
+    *data_ready = (status & 0x7ff) != 0;
+
+    return ESP_OK;
+}
+
+esp_err_t scd4x_persist_settings(i2c_dev_t *dev)
+{
+    return execute_cmd(dev, CMD_PERSIST_SETTINGS, 800, NULL, 0, NULL, 0);
+}
+
+esp_err_t scd4x_get_serial_number(i2c_dev_t *dev, uint16_t *serial0, uint16_t *serial1, uint16_t *serial2)
+{
+    CHECK_ARG(serial0 && serial1 && serial2);
+
+    uint16_t buf[3];
+    CHECK(execute_cmd(dev, CMD_GET_SERIAL_NUMBER, 1, NULL, 0, buf, 3));
+    *serial0 = buf[0];
+    *serial1 = buf[1];
+    *serial2 = buf[2];
+
+    return ESP_OK;
+}
+
+esp_err_t scd4x_perform_self_test(i2c_dev_t *dev, bool *malfunction)
+{
+    CHECK_ARG(malfunction);
+
+    return execute_cmd(dev, CMD_PERFORM_SELF_TEST, 10000, NULL, 0, (uint16_t *)malfunction, 1);
+}
+
+esp_err_t scd4x_perform_factory_reset(i2c_dev_t *dev)
+{
+    return execute_cmd(dev, CMD_PERFORM_FACTORY_RESET, 800, NULL, 0, NULL, 0);
+}
+
+esp_err_t scd4x_reinit(i2c_dev_t *dev)
+{
+    return execute_cmd(dev, CMD_REINIT, 20, NULL, 0, NULL, 0);
+}
+
+esp_err_t scd4x_measure_single_shot(i2c_dev_t *dev)
+{
+    return execute_cmd(dev, CMD_MEASURE_SINGLE_SHOT, 5000, NULL, 0, NULL, 0);
+}
+
+esp_err_t scd4x_measure_single_shot_rht_only(i2c_dev_t *dev)
+{
+    return execute_cmd(dev, CMD_MEASURE_SINGLE_SHOT_RHT_ONLY, 50, NULL, 0, NULL, 0);
+}
+
+esp_err_t scd4x_power_down(i2c_dev_t *dev)
+{
+    return execute_cmd(dev, CMD_POWER_DOWN, 1, NULL, 0, NULL, 0);
+}
+
+esp_err_t scd4x_wake_up(i2c_dev_t *dev)
+{
+    return execute_cmd(dev, CMD_WAKE_UP, 20, NULL, 0, NULL, 0);
+}

--- a/components/scd4x/scd4x.h
+++ b/components/scd4x/scd4x.h
@@ -1,0 +1,428 @@
+/*
+ * Copyright (c) 2021, Sensirion AG
+ * Copyright (c) 2021 Ruslan V. Uss <unclerus@gmail.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of itscontributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file scd4x.h
+ * @defgroup scd4x scd4x
+ * @{
+ *
+ * ESP-IDF driver for SCD4x CO2 sensor.
+ *
+ * Ported from https://github.com/Sensirion/raspberry-pi-i2c-scd4x
+ *
+ * Copyright (c) 2021, Sensirion AG
+ * Copyright (c) 2021 Ruslan V. Uss <unclerus@gmail.com>
+ *
+ * BSD Licensed as described in the file LICENSE
+ */
+#ifndef __SCD4X_H__
+#define __SCD4X_H__
+
+#include <i2cdev.h>
+#include <esp_err.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define SCD4X_I2C_ADDR 0x62
+
+/**
+ * @brief Initialize device descriptor.
+ *
+ * @param dev      Device descriptor
+ * @param port     I2C port
+ * @param sda_gpio SDA GPIO
+ * @param scl_gpio SCL GPIO
+ * @return         `ESP_OK` on success
+ */
+esp_err_t scd4x_init_desc(i2c_dev_t *dev, i2c_port_t port, gpio_num_t sda_gpio, gpio_num_t scl_gpio);
+
+/**
+ * @brief Free device descriptor.
+ *
+ * @param dev Device descriptor
+ * @return    `ESP_OK` on success
+ */
+esp_err_t scd4x_free_desc(i2c_dev_t *dev);
+
+/**
+ * @brief Start periodic measurement.
+ *
+ * Signal update interval is 5 seconds.
+ *
+ * @note This command is only available in idle mode.
+ *
+ * @param dev Device descriptor
+ * @return    `ESP_OK` on success
+ */
+esp_err_t scd4x_start_periodic_measurement(i2c_dev_t *dev);
+
+/**
+ * @brief Read sensor output.
+ *
+ * The measurement data can only be read out once per signal update interval
+ * as the buffer is emptied upon read-out. If no data is available in the
+ * buffer, the sensor returns a NACK. To avoid a NACK response the
+ * ::scd4x_get_data_ready_status() can be called to check data status.
+ *
+ * @note This command is only available in measurement mode. The firmware
+ * updates the measurement values depending on the measurement mode.
+ *
+ * @param dev         Device descriptor
+ * @param co2         CO₂ concentration in ppm
+ * @param temperature Convert value to °C by: -45 °C + 175 °C * value/2^16
+ * @param humidity    Convert value to %RH by: 100%RH * value/2^16
+ * @return            `ESP_OK` on success
+ */
+esp_err_t scd4x_read_measurement_ticks(i2c_dev_t *dev, uint16_t *co2, uint16_t *temperature, uint16_t *humidity);
+
+/**
+ * @brief Read sensor output and convert.
+ *
+ * See ::scd4x_read_measurement_ticks() for more details.
+ *
+ * @note This command is only available in measurement mode. The firmware
+ * updates the measurement values depending on the measurement mode.
+ *
+ * @param dev         Device descriptor
+ * @param co2         CO₂ concentration in ppm
+ * @param temperature Temperature in degrees Celsius (°C)
+ * @param humidity    Relative humidity in percent RH
+ * @return            `ESP_OK` on success
+ */
+esp_err_t scd4x_read_measurement(i2c_dev_t *dev, uint16_t *co2, float *temperature, float *humidity);
+
+/**
+ * @brief Stop periodic measurement.
+ *
+ * Stop periodic measurement and return to idle mode for sensor configuration
+ * or to safe energy.
+ *
+ * @note This command is only available in measurement mode.
+ *
+ * @param dev Device descriptor
+ * @return    `ESP_OK` on success
+ */
+esp_err_t scd4x_stop_periodic_measurement(i2c_dev_t *dev);
+
+/**
+ * @brief Get temperature offset in ticks.
+ *
+ * The temperature offset represents the difference between the measured
+ * temperature by the SCD4x and the actual ambient temperature. Per default,
+ * the temperature offset is set to 4°C.
+ *
+ * @note Only available in idle mode.
+ *
+ * @param dev      Device descriptor
+ * @param t_offset Temperature offset.
+ *                 Convert value to °C by: 175 * value / 2^16
+ * @return         `ESP_OK` on success
+ */
+esp_err_t scd4x_get_temperature_offset_ticks(i2c_dev_t *dev, uint16_t *t_offset);
+
+/**
+ * @brief Get temperature offset in °C.
+ *
+ * See ::scd4x_get_temperature_offset_ticks() for more details.
+ *
+ * @note Only available in idle mode.
+ *
+ * @param dev      Device descriptor
+ * @param t_offset Temperature offset in degrees Celsius (°C)
+ * @return         `ESP_OK` on success
+ */
+esp_err_t scd4x_get_temperature_offset(i2c_dev_t *dev, float *t_offset);
+
+/**
+ * @brief Set temperature offset in ticks.
+ *
+ * Setting the temperature offset of the SCD4x inside the customer device
+ * correctly allows the user to leverage the RH and T output signal. Note
+ * that the temperature offset can depend on various factors such as the
+ * SCD4x measurement mode, self-heating of close components, the ambient
+ * temperature and air flow. Thus, the SCD4x temperature offset should be
+ * determined inside the customer device under its typical operation and in
+ * thermal equilibrium.
+ *
+ * @note Only available in idle mode.
+ *
+ * @param dev      Device descriptor
+ * @param t_offset Temperature offset.
+ *                 Convert °C to value by: T * 2^16 / 175
+ * @return         `ESP_OK` on success
+ */
+esp_err_t scd4x_set_temperature_offset_ticks(i2c_dev_t *dev, uint16_t t_offset);
+
+/**
+ * @brief Set temperature offset in °C.
+ *
+ * See ::scd4x_set_temperature_offset_ticks() for more details.
+ *
+ * @note Only available in idle mode.
+ *
+ * @param dev      Device descriptor
+ * @param t_offset Temperature offset in degrees Celsius (°C)
+ * @return         `ESP_OK` on success
+ */
+esp_err_t scd4x_set_temperature_offset(i2c_dev_t *dev, float t_offset);
+
+/**
+ * @brief Get configured sensor altitude.
+ *
+ * Get configured sensor altitude in meters above sea level. Per default, the
+ * sensor altitude is set to 0 meter above sea-level.
+ *
+ * @note Only available in idle mode.
+ *
+ * @param dev      Device descriptor.
+ * @param altitude Sensor altitude in meters.
+ * @return         `ESP_OK` on success
+ */
+esp_err_t scd4x_get_sensor_altitude(i2c_dev_t *dev, uint16_t *altitude);
+
+/**
+ * @brief Set sensor altitude in meters above sea level.
+ *
+ * Note that setting a sensor altitude to the sensor overrides any pressure
+ * compensation based on a previously set ambient pressure.
+ *
+ * @note Only available in idle mode.
+ *
+ * @param dev      Device descriptor.
+ * @param altitude Sensor altitude in meters.
+ * @return         `ESP_OK` on success
+ */
+esp_err_t scd4x_set_sensor_altitude(i2c_dev_t *dev, uint16_t altitude);
+
+/**
+ * @brief Set ambient pressure.
+ *
+ * The set_ambient_pressure command can be sent during periodic measurements
+ * to enable continuous pressure compensation. Note that setting an ambient
+ * pressure to the sensor overrides any pressure compensation based on a
+ * previously set sensor altitude.
+ *
+ * @note Available during measurements.
+ *
+ * @param dev      Device descriptor.
+ * @param pressure Ambient pressure in hPa.
+ *                 Convert value to Pa by: value * 100
+ * @return         `ESP_OK` on success
+ */
+esp_err_t scd4x_set_ambient_ressure(i2c_dev_t *dev, uint16_t pressure);
+
+/**
+ * @brief Perform forced recalibration.
+ *
+ * To successfully conduct an accurate forced recalibration, the following
+ * steps need to be carried out:
+ * - Operate the SCD4x in a periodic measurement mode for > 3 minutes in an
+ *   environment with homogenous and constant CO₂ concentration.
+ * - Stop periodic measurement. Wait 500 ms.
+ * - Subsequently call scd4x_perform_forced_recalibration() and optionally
+ *   read out the baseline correction. A return value of 0xffff indicates
+ *   that the forced recalibration failed.
+ *
+ * @param dev                      Device descriptor.
+ * @param target_co2_concentration Target CO₂ concentration in ppm.
+ * @param frc_correction           FRC correction value in CO₂ ppm or 0xFFFF
+ *                                 if the command failed.
+ * @return                         `ESP_OK` on success
+ */
+esp_err_t scd4x_perform_forced_recalibration(i2c_dev_t *dev,
+        uint16_t target_co2_concentration, uint16_t *frc_correction);
+
+/**
+ * @brief Get automatic self calibration (ASC) state.
+ *
+ * By default, the ASC is enabled.
+ *
+ * @param dev     Device descriptor.
+ * @param enabled true if ASC is enabled, false otherwise
+ * @return        `ESP_OK` on success
+ */
+esp_err_t scd4x_get_automatic_self_calibration(i2c_dev_t *dev, bool *enabled);
+
+/**
+ * @brief Enable or disable automatic self calibration (ASC).
+ *
+ * By default, the ASC is enabled.
+ *
+ * @param dev     Device descriptor.
+ * @param enabled true to enable ASC, false to disable ASC
+ * @return        `ESP_OK` on success
+ */
+esp_err_t scd4x_set_automatic_self_calibration(i2c_dev_t *dev, bool enabled);
+
+/**
+ * @brief Start low power periodic measurement.
+ *
+ * Signal update interval is 30 seconds.
+ *
+ * @note This command is only available in idle mode.
+ *
+ * @param dev Device descriptor
+ * @return    `ESP_OK` on success
+ */
+esp_err_t scd4x_start_low_power_periodic_measurement(i2c_dev_t *dev);
+
+/**
+ * @brief Check whether new measurement data is available for read-out.
+ *
+ * @param dev        Device descriptor
+ * @param data_ready true if data is ready, false otherwise
+ * @return           `ESP_OK` on success
+ */
+esp_err_t scd4x_get_data_ready_status(i2c_dev_t *dev, bool *data_ready);
+
+/**
+ * @brief Store current configuration in EEPROM.
+ *
+ * Configuration settings such as the temperature offset, sensor altitude and
+ * the ASC enabled/disabled parameter are by default stored in the volatile
+ * memory (RAM) only and will be lost after a power-cycle. This funciton
+ * stores the current configuration in the EEPROM of the SCD4x, making them
+ * resistant to power-cycling. To avoid unnecessary wear of the EEPROM,
+ * function should only be called when persistence is required and if actual
+ * changes to the configuration have been made. Note that field calibration
+ * history (i.e. FRC and ASC) is stored in the EEPROM automatically.
+ *
+ * @param dev Device descriptor
+ * @return    `ESP_OK` on success
+ */
+esp_err_t scd4x_persist_settings(i2c_dev_t *dev);
+
+/**
+ * @brief Read serial number.
+ *
+ * Reading out the serial number can be used to identify the chip and to verify
+ * the presence of the sensor. Function returns 3 words. Together, the 3 words
+ * constitute a unique serial number with a length of 48 bits (big endian format).
+ *
+ * @param dev     Device descriptor
+ * @param serial0 First word of the 48 bit serial number
+ * @param serial1 Second word of the 48 bit serial number
+ * @param serial2 Third word of the 48 bit serial number
+ * @return        `ESP_OK` on success
+ */
+esp_err_t scd4x_get_serial_number(i2c_dev_t *dev, uint16_t *serial0, uint16_t *serial1, uint16_t *serial2);
+
+/**
+ * @brief Perform self-test.
+ *
+ * This function can be used as an  end-of-line test to confirm sensor
+ * functionality.
+ *
+ * @param dev         Device descriptor
+ * @param malfunction true if malfunction detected, false if device is OK
+ * @return            `ESP_OK` on success
+ */
+esp_err_t scd4x_perform_self_test(i2c_dev_t *dev, bool *malfunction);
+
+/**
+ * @brief Factory reset sensor.
+ *
+ * Initiates the reset of all configurations stored in the EEPROM and erases the
+ * FRC and ASC algorithm history.
+ *
+ * @param dev Device descriptor
+ * @return    `ESP_OK` on success
+ */
+esp_err_t scd4x_perform_factory_reset(i2c_dev_t *dev);
+
+/**
+ * @brief Reinitialize sensor.
+ *
+ * The reinit command reinitializes the sensor by reloading user settings from
+ * EEPROM. Before sending the reinit command, the stop measurement command must
+ * be issued. If reinit command does not trigger the desired re-initialization,
+ * a power-cycle should be applied to the SCD4x.
+ *
+ * @note Only available in idle mode.
+ *
+ * @param dev Device descriptor
+ * @return    `ESP_OK` on success
+ */
+esp_err_t scd4x_reinit(i2c_dev_t *dev);
+
+/**
+ * @brief Perform single measurement.
+ *
+ * On-demand measurement of CO₂ concentration, relative humidity and temperature.
+ * The sensor output is read with the ::scd4x_read_measurement() function.
+ *
+ * @note Only available in idle mode.
+ *
+ * @param dev Device descriptor
+ * @return    `ESP_OK` on success
+ */
+esp_err_t scd4x_measure_single_shot(i2c_dev_t *dev);
+
+/**
+ * @brief Perform single measurement of of relative humidity and temperature
+ *        only.
+ *
+ * @note Only available in idle mode.
+ *
+ * @param dev Device descriptor
+ * @return    `ESP_OK` on success
+ */
+esp_err_t scd4x_measure_single_shot_rht_only(i2c_dev_t *dev);
+
+/**
+ * @brief Put the sensor from idle to sleep mode.
+ *
+ * Call this function to reduce current consumption.
+ *
+ * @note Only available in idle mode.
+ *
+ * @param dev Device descriptor
+ * @return    `ESP_OK` on success
+ */
+esp_err_t scd4x_power_down(i2c_dev_t *dev);
+
+/**
+ * @brief Wake up sensor from sleep mode to idle mode.
+ *
+ * @note Only available in sleep mode.
+ *
+ * @param dev Device descriptor
+ * @return    `ESP_OK` on success
+ */
+esp_err_t scd4x_wake_up(i2c_dev_t *dev);
+
+#ifdef __cplusplus
+}
+#endif
+
+/**@}*/
+
+#endif /* __SCD4X_H__ */

--- a/components/si7021/.eil.yml
+++ b/components/si7021/.eil.yml
@@ -1,0 +1,22 @@
+name: si7021
+description: Driver for Si7013/Si7020/Si7021/HTU2xD/SHT2x and compatible temperature and humidity sensors
+version: 1.0.1
+groups:
+  - temperature
+  - humidity
+code_owners: UncleRus
+depends:
+  - i2cdev
+  - log
+  - esp_idf_lib_helpers
+thread_safe: yes
+targets:
+  - esp32
+  - esp32c3
+  - esp8266
+  - esp32s2
+  - esp32c3
+license: BSD-3
+copyrights:
+  - name: UncleRus
+    year: 2019

--- a/components/si7021/CMakeLists.txt
+++ b/components/si7021/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(
+    SRCS si7021.c
+    INCLUDE_DIRS .
+    REQUIRES i2cdev log esp_idf_lib_helpers
+)

--- a/components/si7021/LICENSE
+++ b/components/si7021/LICENSE
@@ -1,0 +1,26 @@
+Copyright (c) 2019 Ruslan V. Uss <unclerus@gmail.com>
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of itscontributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/components/si7021/component.mk
+++ b/components/si7021/component.mk
@@ -1,0 +1,2 @@
+COMPONENT_ADD_INCLUDEDIRS = .
+COMPONENT_DEPENDS = i2cdev log esp_idf_lib_helpers

--- a/components/si7021/si7021.c
+++ b/components/si7021/si7021.c
@@ -1,0 +1,331 @@
+/*
+ * Copyright (c) 2019 Ruslan V. Uss <unclerus@gmail.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of itscontributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file si7021.c
+ *
+ * ESP-IDF driver for Si7013/Si7020/Si7021/HTU2xD/SHT2x and
+ * compatible temperature and humidity sensors
+ *
+ * Copyright (c) 2019 Ruslan V. Uss <unclerus@gmail.com>
+ *
+ * BSD Licensed as described in the file LICENSE
+ */
+#include <esp_log.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+#include <esp_idf_lib_helpers.h>
+#include "si7021.h"
+
+#define I2C_FREQ_HZ 400000 // 400kHz
+
+static const char *TAG = "si7021";
+
+#define DELAY_MS 100  // fixed delay (100 ms for SHT20)
+
+#define CMD_MEAS_RH_HOLD     0xe5 // not used, can't stretch clock
+#define CMD_MEAS_RH_NOHOLD   0xf5
+#define CMD_MEAS_T_HOLD      0xe3 // not used, can't stretch clock
+#define CMD_MEAS_T_NOHOLD    0xf3
+#define CMD_READ_T           0xe0 // not used
+#define CMD_RESET            0xfe
+#define CMD_WRITE_USER_REG   0xe6
+#define CMD_READ_USER_REG    0xe7
+#define CMD_WRITE_HEATER_REG 0x51
+#define CMD_READ_HEATER_REG  0x11
+#define CMD_READ_ID_1        0x0ffa
+#define CMD_READ_ID_2        0xc9fc
+#define CMD_READ_FW_REV_1    0xb884
+
+#define BIT_USER_REG_RES0 0
+#define BIT_USER_REG_HTRE 2
+#define BIT_USER_REG_RES1 7
+
+#define HEATER_MASK 0x0f
+
+#define BV(x) (1 << (x))
+
+#define CHECK(x) do { esp_err_t __; if ((__ = x) != ESP_OK) return __; } while (0)
+#define CHECK_ARG(VAL) do { if (!(VAL)) return ESP_ERR_INVALID_ARG; } while (0)
+
+static bool check_crc(uint16_t value, uint8_t crc)
+{
+    uint32_t row = (uint32_t)value << 8;
+    row |= crc;
+
+    uint32_t divisor = 0x988000;
+
+    for (int i = 0; i < 16; i++)
+    {
+        if (row & (uint32_t)1 << (23 - i))
+            row ^= divisor;
+        divisor >>= 1;
+    }
+
+    return !row;
+}
+
+static esp_err_t measure(i2c_dev_t *dev, uint8_t cmd, uint16_t *raw)
+{
+    I2C_DEV_TAKE_MUTEX(dev);
+    // write command
+    I2C_DEV_CHECK(dev, i2c_dev_write(dev, NULL, 0, &cmd, 1));
+
+    // wait
+    vTaskDelay(DELAY_MS / portTICK_PERIOD_MS);
+
+    // read data
+    uint8_t buf[3];
+    I2C_DEV_CHECK(dev, i2c_dev_read(dev, NULL, 0, buf, 3));
+    I2C_DEV_GIVE_MUTEX(dev);
+
+    *raw = ((uint16_t)buf[0] << 8) | buf[1];
+
+    if (!check_crc(*raw, buf[2]))
+    {
+        ESP_LOGE(TAG, "Invalid CRC");
+        return ESP_ERR_INVALID_RESPONSE;
+    }
+
+    return ESP_OK;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+esp_err_t si7021_init_desc(i2c_dev_t *dev, i2c_port_t port, gpio_num_t sda_gpio, gpio_num_t scl_gpio)
+{
+    CHECK_ARG(dev);
+
+    dev->port = port;
+    dev->addr = SI7021_I2C_ADDR;
+    dev->cfg.sda_io_num = sda_gpio;
+    dev->cfg.scl_io_num = scl_gpio;
+#if HELPER_TARGET_IS_ESP32
+    dev->cfg.master.clk_speed = I2C_FREQ_HZ;
+#endif
+
+    return i2c_dev_create_mutex(dev);
+}
+
+esp_err_t si7021_free_desc(i2c_dev_t *dev)
+{
+    CHECK_ARG(dev);
+
+    return i2c_dev_delete_mutex(dev);
+}
+
+esp_err_t si7021_reset(i2c_dev_t *dev)
+{
+    CHECK_ARG(dev);
+
+    uint8_t cmd = CMD_RESET;
+    I2C_DEV_TAKE_MUTEX(dev);
+    I2C_DEV_CHECK(dev, i2c_dev_write(dev, NULL, 0, &cmd, 1));
+    I2C_DEV_GIVE_MUTEX(dev);
+
+    vTaskDelay(pdMS_TO_TICKS(DELAY_MS));
+
+    return ESP_OK;
+}
+
+esp_err_t si7021_get_heater(i2c_dev_t *dev, bool *on)
+{
+    CHECK_ARG(dev && on);
+
+    uint8_t u;
+
+    I2C_DEV_TAKE_MUTEX(dev);
+    I2C_DEV_CHECK(dev, i2c_dev_read_reg(dev, CMD_READ_USER_REG, &u, 1));
+    I2C_DEV_GIVE_MUTEX(dev);
+
+    *on = u & BV(BIT_USER_REG_HTRE);
+
+    return ESP_OK;
+}
+
+esp_err_t si7021_set_heater(i2c_dev_t *dev, bool on)
+{
+    CHECK_ARG(dev);
+
+    uint8_t u;
+
+    I2C_DEV_TAKE_MUTEX(dev);
+    I2C_DEV_CHECK(dev, i2c_dev_read_reg(dev, CMD_READ_USER_REG, &u, 1));
+    u = (u & ~BV(BIT_USER_REG_HTRE)) | (on ? 1 : 0);
+    I2C_DEV_CHECK(dev, i2c_dev_write_reg(dev, CMD_WRITE_USER_REG, &u, 1));
+    I2C_DEV_GIVE_MUTEX(dev);
+
+    return ESP_OK;
+}
+
+esp_err_t si7021_get_heater_current(i2c_dev_t *dev, uint8_t *level)
+{
+    CHECK_ARG(dev && level);
+
+    uint8_t h;
+
+    I2C_DEV_TAKE_MUTEX(dev);
+    I2C_DEV_CHECK(dev, i2c_dev_read_reg(dev, CMD_READ_HEATER_REG, &h, 1));
+    I2C_DEV_GIVE_MUTEX(dev);
+
+    *level = h & HEATER_MASK;
+
+    return ESP_OK;
+}
+
+esp_err_t si7021_set_heater_current(i2c_dev_t *dev, uint8_t level)
+{
+    CHECK_ARG(dev && level <= SI7021_MAX_HEATER_CURRENT);
+
+    I2C_DEV_TAKE_MUTEX(dev);
+    I2C_DEV_CHECK(dev, i2c_dev_write_reg(dev, CMD_WRITE_HEATER_REG, &level, 1));
+    I2C_DEV_GIVE_MUTEX(dev);
+
+    return ESP_OK;
+}
+
+esp_err_t si7021_get_resolution(i2c_dev_t *dev, si7021_resolution_t *r)
+{
+    CHECK_ARG(dev && r);
+
+    uint8_t u;
+
+    I2C_DEV_TAKE_MUTEX(dev);
+    I2C_DEV_CHECK(dev, i2c_dev_read_reg(dev, CMD_READ_USER_REG, &u, 1));
+    I2C_DEV_GIVE_MUTEX(dev);
+
+    *r = ((u >> BIT_USER_REG_RES1) << 1) | (u & BV(BIT_USER_REG_RES0));
+
+    return ESP_OK;
+}
+
+esp_err_t si7021_set_resolution(i2c_dev_t *dev, si7021_resolution_t r)
+{
+    CHECK_ARG(dev && r <= SI7021_RES_RH11_T11);
+
+    uint8_t u;
+
+    I2C_DEV_TAKE_MUTEX(dev);
+    I2C_DEV_CHECK(dev, i2c_dev_read_reg(dev, CMD_READ_USER_REG, &u, 1));
+    u = (u & ~(BV(BIT_USER_REG_RES0) | BV(BIT_USER_REG_RES1))) | ((r & 2) << (BIT_USER_REG_RES1 - 1)) | (r & 1);
+    I2C_DEV_CHECK(dev, i2c_dev_write_reg(dev, CMD_WRITE_USER_REG, &u, 1));
+    I2C_DEV_GIVE_MUTEX(dev);
+
+    return ESP_OK;
+}
+
+esp_err_t si7021_measure_temperature(i2c_dev_t *dev, float *t)
+{
+    CHECK_ARG(dev && t);
+
+    uint16_t raw;
+    CHECK(measure(dev, CMD_MEAS_T_NOHOLD, &raw));
+    *t = raw * 175.72 / 65536 - 46.85;
+
+    return ESP_OK;
+}
+
+esp_err_t si7021_measure_humidity(i2c_dev_t *dev, float *rh)
+{
+    CHECK_ARG(dev && rh);
+
+    uint16_t raw;
+    CHECK(measure(dev, CMD_MEAS_RH_NOHOLD, &raw));
+    *rh = raw * 125.0 / 65536 - 6;
+
+    return ESP_OK;
+}
+
+esp_err_t si7021_get_serial(i2c_dev_t *dev, uint64_t *serial, bool sht2x_mode)
+{
+    CHECK_ARG(dev && serial);
+
+    uint8_t buf[8];
+    uint16_t cmd;
+
+    I2C_DEV_TAKE_MUTEX(dev);
+
+    // read SNA, ignore CRC
+    cmd = CMD_READ_ID_1;
+    I2C_DEV_CHECK(dev, i2c_dev_read(dev, &cmd, 2, buf, 8));
+    *serial = sht2x_mode
+        ? ((uint64_t)buf[0] << 40) | ((uint64_t)buf[2] << 32) | ((uint64_t)buf[4] << 24) | ((uint64_t)buf[6] << 16)
+        : ((uint64_t)buf[0] << 56) | ((uint64_t)buf[2] << 48) | ((uint64_t)buf[4] << 40) | ((uint64_t)buf[6] << 32);
+
+    // read SNB, ignore CRC
+    cmd = CMD_READ_ID_2;
+    I2C_DEV_CHECK(dev, i2c_dev_read(dev, &cmd, 2, buf, 6));
+    *serial |= sht2x_mode
+        ? ((uint32_t)buf[0] << 8) | ((uint64_t)buf[3] << 56) | ((uint64_t)buf[4] << 48) | buf[1]
+        : ((uint32_t)buf[0] << 24) | ((uint32_t)buf[1] << 16) | ((uint32_t)buf[3] << 8) | buf[4];
+
+    I2C_DEV_GIVE_MUTEX(dev);
+
+    return ESP_OK;
+}
+
+esp_err_t si7021_get_device_id(i2c_dev_t *dev, si7021_device_id_t *id)
+{
+    CHECK_ARG(id);
+
+    uint64_t serial;
+    CHECK(si7021_get_serial(dev, &serial, false));
+
+    switch ((serial >> 24) & 0xff)
+    {
+        case 0x0d:
+            *id = SI_MODEL_SI7013;
+            break;
+        case 0x14:
+            *id = SI_MODEL_SI7020;
+            break;
+        case 0x15:
+            *id = SI_MODEL_SI7021;
+            break;
+        case 0x00:
+        case 0xff:
+            *id = SI_MODEL_SAMPLE;
+            break;
+        default:
+            *id = SI_MODEL_UNKNOWN;
+    }
+
+    return ESP_OK;
+}
+
+esp_err_t si7021_get_device_revision(i2c_dev_t *dev, uint8_t *rev)
+{
+    CHECK_ARG(dev && rev);
+
+    uint16_t cmd = CMD_READ_FW_REV_1;
+
+    I2C_DEV_TAKE_MUTEX(dev);
+    I2C_DEV_CHECK(dev, i2c_dev_read(dev, &cmd, 2, rev, 1));
+    I2C_DEV_GIVE_MUTEX(dev);
+
+    return ESP_OK;
+}

--- a/components/si7021/si7021.h
+++ b/components/si7021/si7021.h
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) 2019 Ruslan V. Uss <unclerus@gmail.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of itscontributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file si7021.h
+ * @defgroup si7021 si7021
+ * @{
+ *
+ * ESP-IDF driver for Si7013/Si7020/Si7021/HTU2xD/SHT2x and
+ * compatible temperature and humidity sensors
+ *
+ * Copyright (c) 2019 Ruslan V. Uss <unclerus@gmail.com>
+ *
+ * BSD Licensed as described in the file LICENSE
+ */
+#ifndef __SI7021_H__
+#define __SI7021_H__
+
+#include <stdbool.h>
+#include <i2cdev.h>
+#include <esp_err.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define SI7021_I2C_ADDR 0x40 //!< I2C address
+
+#define SI7021_MAX_HEATER_CURRENT 0x0f //!< Maximum current of the heater for Si70xx
+
+/**
+ * Device model for Si70xx
+ */
+typedef enum {
+    SI_MODEL_SI7013 = 0, //!< Si7013
+    SI_MODEL_SI7020,     //!< Si7020
+    SI_MODEL_SI7021,     //!< Si7021
+    SI_MODEL_SAMPLE,     //!< Engineering sample
+    SI_MODEL_UNKNOWN     //!< Unknown model
+} si7021_device_id_t;
+
+/**
+ * Measurement resolution
+ */
+typedef enum {
+    SI7021_RES_RH12_T14 = 0, //!< Relative humidity: 12 bits, temperature: 14 bits
+    SI7021_RES_RH08_T12,     //!< Relative humidity: 8 bits, temperature: 12 bits
+    SI7021_RES_RH10_T13,     //!< Relative humidity: 10 bits, temperature: 13 bits
+    SI7021_RES_RH11_T11      //!< Relative humidity: 11 bits, temperature: 11 bits
+} si7021_resolution_t;
+
+/**
+ * @brief Initialize device descriptor
+ *
+ * @param dev       Device descriptor
+ * @param port      I2C port
+ * @param sda_gpio  SDA GPIO pin
+ * @param scl_gpio  SCL GPIO pin
+ * @return `ESP_OK` on success
+ */
+esp_err_t si7021_init_desc(i2c_dev_t *dev, i2c_port_t port, gpio_num_t sda_gpio, gpio_num_t scl_gpio);
+
+/**
+ * @brief Free device descriptor
+ *
+ * @param dev Device descriptor
+ * @return `ESP_OK` on success
+ */
+esp_err_t si7021_free_desc(i2c_dev_t *dev);
+
+/**
+ * @brief Reset device
+ * @param dev Device descriptor
+ * @return `ESP_OK` on success
+ */
+esp_err_t si7021_reset(i2c_dev_t *dev);
+
+/**
+ * @brief Get heater state
+ *
+ * This function is supported by:
+ *
+ *  - SI7013
+ *  - SI7020
+ *  - SI7021
+ *  - SHT2x
+ *
+ * @param dev      Device descriptor
+ * @param[out] on  `true` if heater enabled
+ * @return `ESP_OK` on success
+ */
+esp_err_t si7021_get_heater(i2c_dev_t *dev, bool *on);
+
+/**
+ * @brief Switch heater on/off
+ *
+ * This function is supported by:
+ *
+ *  - SI7013
+ *  - SI7020
+ *  - SI7021
+ *  - SHT2x
+ *
+ * @param dev   Device descriptor
+ * @param on    if `true`, heater will be enabled
+ * @return `ESP_OK` on success
+ */
+esp_err_t si7021_set_heater(i2c_dev_t *dev, bool on);
+
+/**
+ * @brief Get heater current
+ *
+ * This function is supported by:
+ *
+ *  - SI7013
+ *  - SI7020
+ *  - SI7021
+ *
+ * @param dev         Device descriptor
+ * @param[out] level  Heater current, see datasheet
+ * @return `ESP_OK` on success
+ */
+esp_err_t si7021_get_heater_current(i2c_dev_t *dev, uint8_t *level);
+
+/**
+ * @brief Set heater current
+ *
+ * This function is supported by:
+ *
+ *  - SI7013
+ *  - SI7020
+ *  - SI7021
+ *
+ * @param dev       Device descriptor
+ * @param level     Heater current, see datasheet
+ * @return `ESP_OK` on success
+ */
+esp_err_t si7021_set_heater_current(i2c_dev_t *dev, uint8_t level);
+
+/**
+ * @brief Get measurement resolution
+ *
+ * @param dev       Device descriptor
+ * @param[out] r    Resolution
+ * @return `ESP_OK` on success
+ */
+esp_err_t si7021_get_resolution(i2c_dev_t *dev, si7021_resolution_t *r);
+
+/**
+ * @brief Set measurement resolution
+ *
+ * @param dev   Device descriptor
+ * @param r     Resolution
+ * @return `ESP_OK` on success
+ */
+esp_err_t si7021_set_resolution(i2c_dev_t *dev, si7021_resolution_t r);
+
+/**
+ * @brief Measure temperature
+ *
+ * @param dev     Device descriptor
+ * @param[out] t  Temperature, deg. Celsius
+ * @return `ESP_OK` on success
+ */
+esp_err_t si7021_measure_temperature(i2c_dev_t *dev, float *t);
+
+/**
+ * @brief Measure relative humidity
+ *
+ * @param dev       Device descriptor
+ * @param[out] rh   Relative humidity, %
+ * @return `ESP_OK` on success
+ */
+esp_err_t si7021_measure_humidity(i2c_dev_t *dev, float *rh);
+
+/**
+ * @brief Get serial number of device
+ *
+ * This function is supported by:
+ *
+ *  - SI7013
+ *  - SI7020
+ *  - SI7021
+ *  - SHT2x
+ *
+ * @param dev          Device descriptor
+ * @param[out] serial  Serial no.
+ * @param sht2x_mode   `true` for SHT2x devices
+ * @return `ESP_OK` on success
+ */
+esp_err_t si7021_get_serial(i2c_dev_t *dev, uint64_t *serial, bool sht2x_mode);
+
+/**
+ * @brief Get device model
+ *
+ * This function is supported by:
+ *
+ *  - SI7013
+ *  - SI7020
+ *  - SI7021
+ *
+ * @param dev       Device descriptor
+ * @param[out] id   Device model
+ * @return `ESP_OK` on success
+ */
+esp_err_t si7021_get_device_id(i2c_dev_t *dev, si7021_device_id_t *id);
+
+/**
+ * @brief Get device revision
+ *
+ * This function is supported by:
+ *
+ *  - SI7013
+ *  - SI7020
+ *  - SI7021
+ *
+ * @param dev       Device descriptor
+ * @param[out] rev  Device revision
+ * @return `ESP_OK` on success
+ */
+esp_err_t si7021_get_device_revision(i2c_dev_t *dev, uint8_t *rev);
+
+#ifdef __cplusplus
+}
+#endif
+
+/**@}*/
+
+#endif /* __SI7021_H__ */

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -24,6 +24,7 @@ idf_component_register(
 		modules/sensors/dht/sensor_dht.c
 		modules/sensors/bmp280/sensor_bmp280.c
 		modules/sensors/ds18b20/sensor_ds18b20.c
+		modules/sensors/siht/sensor_siht.c
 
 		modules/virtual/battery/battery.c
 		modules/virtual/deepsleep/deepsleep.c

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -25,6 +25,7 @@ idf_component_register(
 		modules/sensors/bmp280/sensor_bmp280.c
 		modules/sensors/ds18b20/sensor_ds18b20.c
 		modules/sensors/siht/sensor_siht.c
+		modules/sensors/scd4x/sensor_scd4x.c
 
 		modules/virtual/battery/battery.c
 		modules/virtual/deepsleep/deepsleep.c

--- a/main/modules/sensor_init.c
+++ b/main/modules/sensor_init.c
@@ -15,6 +15,7 @@
 #include "sensors/ds18b20/sensor_ds18b20.h"
 // #include "exec/led_light/led_light.h"
 #include "sensors/siht/sensor_siht.h"
+#include "sensors/scd4x/sensor_scd4x.h"
 
 extern cJSON *sensor_json;
 static const char *TAG = "sensor_init";
@@ -92,6 +93,10 @@ void sensor_init(void)
             else if (strcmp(sensor, "SiHT") == 0)
             {
                 sensor_siht(sensor, cluster, EP, &taskParams);
+            }
+            else if (strcmp(sensor, "SCD4x") == 0)
+            {
+                sensor_scd4x(sensor, cluster, EP, &taskParams);
             }
             else if (strcmp(sensor, "battery") == 0)
             {

--- a/main/modules/sensor_init.c
+++ b/main/modules/sensor_init.c
@@ -14,6 +14,7 @@
 #include "virtual/deepsleep/deepsleep.h"
 #include "sensors/ds18b20/sensor_ds18b20.h"
 // #include "exec/led_light/led_light.h"
+#include "sensors/siht/sensor_siht.h"
 
 extern cJSON *sensor_json;
 static const char *TAG = "sensor_init";
@@ -88,13 +89,17 @@ void sensor_init(void)
             {
                 sensor_bmp280(sensor, cluster, EP, &taskParams);
             }
+            else if (strcmp(sensor, "SiHT") == 0)
+            {
+                sensor_siht(sensor, cluster, EP, &taskParams);
+            }
             else if (strcmp(sensor, "battery") == 0)
             {
                 cluster_battery(sensor, cluster, EP, &taskParams);
             }
             else if (strcmp(sensor, "deepsleep") == 0)
             {
-                deep_sleep(sensor, cluster, EP, &taskParams);               
+                deep_sleep(sensor, cluster, EP, &taskParams);
             }
             else if (strcmp(sensor, "DS18b20") == 0)
             {

--- a/main/modules/sensors/aht/sensor_aht.c
+++ b/main/modules/sensors/aht/sensor_aht.c
@@ -75,8 +75,19 @@ static void sensor_aht_task(void *pvParameters)
     dev.mode = AHT_MODE_NORMAL;
     dev.type = AHT_TYPE;
 
-    ESP_ERROR_CHECK(aht_init_desc(&dev, ADDR, 0, param_pin_SDA, param_pin_SCL));
-    ESP_ERROR_CHECK(aht_init(&dev));
+    esp_err_t init_desc_err = aht_init_desc(&dev, ADDR, 0, param_pin_SDA, param_pin_SCL);
+    if (init_desc_err != ESP_OK)
+    {
+        ESP_LOGE(TAG, "Failed to initialize device descriptor: %s", esp_err_to_name(init_desc_err));
+        vTaskDelete(NULL);
+    }
+    
+    esp_err_t init_err = aht_init(&dev);
+    if (init_err != ESP_OK)
+    {
+        ESP_LOGE(TAG, "Failed to initialize AHT: %s", esp_err_to_name(init_err));
+        vTaskDelete(NULL);
+    }
 
     bool calibrated;
     ESP_ERROR_CHECK(aht_get_status(&dev, NULL, &calibrated));

--- a/main/modules/sensors/bmp280/sensor_bmp280.c
+++ b/main/modules/sensors/bmp280/sensor_bmp280.c
@@ -55,10 +55,20 @@ static void sensor_bmp280_task(void *pvParameters)
     bmp280_t dev;
     memset(&dev, 0, sizeof(bmp280_t));
 
-    ESP_ERROR_CHECK(bmp280_init_desc(&dev, I2C_ADDRESS_int, 0, param_pin_SDA, param_pin_SCL));
+    esp_err_t init_desc_err = bmp280_init_desc(&dev, I2C_ADDRESS_int, 0, param_pin_SDA, param_pin_SCL);
+    if (init_desc_err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to initialize device descriptor: %s", esp_err_to_name(init_desc_err));
+        vTaskDelete(NULL); 
+    }
+
     // BMP280_I2C_ADDRESS_0
     // ESP_ERROR_CHECK(bmp280_init_desc(&dev, BMP280_I2C_ADDRESS_1, 0, param_pin_SDA, param_pin_SCL));
-    ESP_ERROR_CHECK(bmp280_init(&dev, &params_bmp280));
+
+    esp_err_t init_err = bmp280_init(&dev, &params_bmp280);
+    if (init_err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to initialize BMP280: %s", esp_err_to_name(init_err));
+        vTaskDelete(NULL); 
+    }
 
     bool bme280p = dev.id == BME280_CHIP_ID;
 

--- a/main/modules/sensors/scd4x/info.json
+++ b/main/modules/sensors/scd4x/info.json
@@ -2,19 +2,20 @@
     "menuSection": "sensors",
     "configItem": [
         {
-            "name": "Si70xx/HTU2xD/SHT2x (temperature humidity)",
-            "sensor": "SiHT",
-            "id": "siht",
+            "name": "SCD4x CO2 + temperature, humidity",
+            "sensor": "SCD4x",
+            "id": "scd4x",
             "int": 60,
             "pin_SCL": 7,
             "pin_SDA": 6,
             "clusters": [
                 "all",
+                "co2",
                 "temperature",
                 "humidity"
             ],
             "EP": 1,
-            "descr": "Датчик температуры / влажности"
+            "descr": "Датчик CO2 + температура + влажность"
         }
     ],
     "about": {
@@ -22,10 +23,10 @@
         "authorContact": "https://t.me/xyzroe",
         "authorGit": "https://github.com/xyzroe",
         "specialThanks": "",
-        "moduleName": "siht",
+        "moduleName": "scd4x",
         "moduleVersion": "1.0",
-        "title": "Сенсор температуры и влажности Si7021",
-        "moduleDesc": "Позволяет получить значения температуры и влажности с Si7013/Si7020/Si7021/HTU2xD/SHT2x.",
+        "title": "Датчик SCD4x CO2",
+        "moduleDesc": "Позволяет получить значения углекислого, температуры и влажности с датчиков Sensirion SCD4x.",
         "retInfo": "",
         "propInfo": {
             "int": "Количество секунд между опросами датчика.",

--- a/main/modules/sensors/scd4x/sensor_scd4x.c
+++ b/main/modules/sensors/scd4x/sensor_scd4x.c
@@ -1,0 +1,122 @@
+#include <stdio.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_log.h"
+#include "esp_err.h"
+#include "cJSON.h"
+#include "string.h"
+#include "../../../utils/send_data.h"
+#include "../../sensor_init.h"
+#include "scd4x.h"
+
+static const char *TAG = "sensor_scd4x";
+
+static void sensor_scd4x_task(void *pvParameters)
+{
+    TaskParameters *params = (TaskParameters *)pvParameters;
+    char *param_id = params->param_id;
+    char id[30] = "";
+    strcpy(id, param_id);
+    gpio_num_t param_pin_SCL = params->param_pin_SCL;
+    gpio_num_t param_pin_SDA = params->param_pin_SDA;
+
+    char *param_cluster = params->param_cluster;
+    char cluster[30] = "";
+    strcpy(cluster, param_cluster);
+
+    int param_ep = params->param_ep;
+    int param_int = params->param_int * 1000;
+
+    i2c_dev_t dev;
+    memset(&dev, 0, sizeof(i2c_dev_t));
+
+    esp_err_t init_desc_err = scd4x_init_desc(&dev, 0, param_pin_SDA, param_pin_SCL);
+    if (init_desc_err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to initialize device descriptor: %s", esp_err_to_name(init_desc_err));
+        vTaskDelete(NULL); 
+    }
+   
+    ESP_LOGI(TAG, "Initializing sensor...");
+    if (scd4x_wake_up(&dev) != ESP_OK ||
+        scd4x_stop_periodic_measurement(&dev) != ESP_OK ||
+        scd4x_reinit(&dev) != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to initialize sensor");
+        vTaskDelete(NULL);
+    }
+    ESP_LOGI(TAG, "Sensor initialized");
+
+    uint16_t serial[3];
+    if (scd4x_get_serial_number(&dev, serial, serial + 1, serial + 2) != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to get sensor serial number");
+        vTaskDelete(NULL);
+    }
+    ESP_LOGI(TAG, "Sensor serial number: 0x%04x%04x%04x", serial[0], serial[1], serial[2]);
+
+    uint16_t co2;
+    float temperature, humidity;
+
+    while (1)
+    {
+        ESP_ERROR_CHECK(scd4x_measure_single_shot(&dev));
+
+        // Wait for data to be ready
+        bool data_ready = false;
+        while (!data_ready)
+        {
+            vTaskDelay(pdMS_TO_TICKS(100)); // Poll every 100ms
+            ESP_ERROR_CHECK(scd4x_get_data_ready_status(&dev, &data_ready));
+        }
+
+        esp_err_t res = scd4x_read_measurement(&dev, &co2, &temperature, &humidity);
+        if (res != ESP_OK)
+        {
+            ESP_LOGE(TAG, "Error reading results %d (%s)", res, esp_err_to_name(res));
+            continue;
+        }
+
+        if (co2 == 0)
+        {
+            ESP_LOGW(TAG, "Invalid sample detected, skipping");
+            continue;
+        }
+
+        ESP_LOGI(TAG, "CO2: %u ppm", co2);
+        ESP_LOGI(TAG, "Temperature: %.2f °C", temperature);
+        ESP_LOGI(TAG, "Humidity: %.2f %%", humidity);
+
+        if (strcmp(cluster, "all") == 0)
+        {
+            uint16_t scd4x_co2 = co2;
+            send_data(scd4x_co2, param_ep, "co2");
+
+            uint16_t scd4x_temp = (uint16_t)(temperature * 100);
+            send_data(scd4x_temp, param_ep, "temperature");
+
+            uint16_t scd4x_humid = (uint16_t)(humidity * 100);
+            send_data(scd4x_humid, param_ep, "humidity");
+        }
+        else if (strcmp(cluster, "co2") == 0)
+        {
+            uint16_t scd4x_val = co2;
+            send_data(scd4x_val, param_ep, cluster);
+        }
+        else if (strcmp(cluster, "temperature") == 0)
+        {
+            uint16_t scd4x_val = (uint16_t)(temperature * 100);
+            send_data(scd4x_val, param_ep, cluster);
+        }
+        else if (strcmp(cluster, "humidity") == 0)
+        {
+            uint16_t scd4x_val = (uint16_t)(humidity * 100);
+            send_data(scd4x_val, param_ep, cluster);
+        }
+
+        vTaskDelay(param_int / portTICK_PERIOD_MS); // Wait for the specified interval before next measurement
+    }
+}
+
+void sensor_scd4x(const char *sensor, const char *cluster, int EP, const TaskParameters *taskParams)
+{
+    ESP_LOGW(TAG, "Task: %s created. Cluster: %s EP: %d", sensor, cluster, EP);
+    xTaskCreate(sensor_scd4x_task, taskParams->param_id, 4096, taskParams, 5, NULL);
+}

--- a/main/modules/sensors/scd4x/sensor_scd4x.h
+++ b/main/modules/sensors/scd4x/sensor_scd4x.h
@@ -1,0 +1,1 @@
+void sensor_scd4x(const char *sensor, const char *cluster, int EP, const TaskParameters *taskParams);

--- a/main/modules/sensors/siht/info.json
+++ b/main/modules/sensors/siht/info.json
@@ -1,0 +1,41 @@
+{
+    "menuSection": "sensors",
+    "configItem": [
+        {
+            "name": "Si70xx/HTU2xD/SHT2x (temperature humidity)",
+            "sensor": "SiHT",
+            "id": "siht",
+            "int": 60,
+            "pin_SCL": 7,
+            "pin_SDA": 6,
+            "clusters": [
+                "all",
+                "temperature",
+                "humidity"
+            ],
+            "EP": 1,
+            "descr": "Датчик температуры / влажности"
+        }
+    ],
+    "about": {
+        "authorName": "xyzroe",
+        "authorContact": "https://t.me/xyzroe",
+        "authorGit": "https://github.com/xyzroe",
+        "specialThanks": "",
+        "moduleName": "si7021",
+        "moduleVersion": "1.0",
+        "title": "Сенсор температуры и влажности Si7021",
+        "moduleDesc": "Позволяет получить значения температуры и влажности с Si7013/Si7020/Si7021/HTU2xD/SHT2x.",
+        "retInfo": "",
+        "propInfo": {
+            "int": "Количество секунд между опросами датчика.",
+            "pin_SDA": "Укажите GPIO номер пина",
+            "pin_SCL": "Укажите GPIO номер пина"
+        }
+    },
+    "defActive": true,
+    "usedLibs": {
+        "esp32_C6": [],
+        "esp32_H2": []
+    }
+}

--- a/main/modules/sensors/siht/sensor_siht.c
+++ b/main/modules/sensors/siht/sensor_siht.c
@@ -1,0 +1,86 @@
+#include <stdio.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_log.h"
+#include "esp_err.h"
+#include "cJSON.h"
+#include "string.h"
+#include "../../../utils/send_data.h"
+#include "../../sensor_init.h"
+#include "si7021.h"
+
+static const char *TAG = "sensor_siht";
+
+static void sensor_siht_task(void *pvParameters)
+{
+    TaskParameters *params = (TaskParameters *)pvParameters;
+    char *param_id = params->param_id;
+    char id[30] = "";
+    strcpy(id, param_id);
+    gpio_num_t param_pin_SCL = params->param_pin_SCL;
+    gpio_num_t param_pin_SDA = params->param_pin_SDA;
+
+    char *param_cluster = params->param_cluster;
+    char cluster[30] = "";
+    strcpy(cluster, param_cluster);
+
+    int param_ep = params->param_ep;
+    int param_int = params->param_int * 1000;
+
+    i2c_dev_t dev;
+    memset(&dev, 0, sizeof(i2c_dev_t));
+
+    esp_err_t init_desc_err = si7021_init_desc(&dev, 0, param_pin_SDA, param_pin_SCL);
+    if (init_desc_err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to initialize device descriptor: %s", esp_err_to_name(init_desc_err));
+        vTaskDelete(NULL); 
+    }
+
+    float temperature, humidity;
+
+    vTaskDelay(pdMS_TO_TICKS(1000)); // Wait for the device to boot
+
+    while (1)
+    {
+        esp_err_t res = si7021_measure_temperature(&dev, &temperature);
+        if (res != ESP_OK) {
+            ESP_LOGE(TAG, "Could not measure temperature: %d (%s)", res, esp_err_to_name(res));
+        } else {
+            ESP_LOGI(TAG, "Temperature: %.2f", temperature);
+        }
+
+        res = si7021_measure_humidity(&dev, &humidity);
+        if (res != ESP_OK) {
+            ESP_LOGE(TAG, "Could not measure humidity: %d (%s)", res, esp_err_to_name(res));
+        } else {
+            ESP_LOGI(TAG, "Humidity: %.2f", humidity);
+        }
+
+        if (strcmp(cluster, "all") == 0)
+        {
+            uint16_t si7021_temp = (uint16_t)(temperature * 100);
+            send_data(si7021_temp, param_ep, "temperature");
+
+            uint16_t si7021_humid = (uint16_t)(humidity * 100);
+            send_data(si7021_humid, param_ep, "humidity");
+        }
+        else if (strcmp(cluster, "temperature") == 0)
+        {
+            uint16_t si7021_val = (uint16_t)(temperature * 100);
+            send_data(si7021_val, param_ep, cluster);
+        }
+        else if (strcmp(cluster, "humidity") == 0)
+        {
+            uint16_t si7021_val = (uint16_t)(humidity * 100);
+            send_data(si7021_val, param_ep, cluster);
+        }
+
+        vTaskDelay(param_int / portTICK_PERIOD_MS);
+    }
+}
+
+void sensor_siht(const char *sensor, const char *cluster, int EP, const TaskParameters *taskParams)
+{
+    ESP_LOGW(TAG, "Task: %s created. Cluster: %s EP: %d", sensor, cluster, EP);
+    xTaskCreate(sensor_siht_task, taskParams->param_id, 4096, taskParams, 5, NULL);
+}

--- a/main/modules/sensors/siht/sensor_siht.h
+++ b/main/modules/sensors/siht/sensor_siht.h
@@ -1,0 +1,1 @@
+void sensor_siht(const char *sensor, const char *cluster, int EP, const TaskParameters *taskParams);

--- a/main/utils/send_data.c
+++ b/main/utils/send_data.c
@@ -80,6 +80,18 @@ void send_data(uint16_t sensor_val, int param_ep, char *cluster)
 
             // reportAttribute(param_ep, ESP_ZB_ZCL_CLUSTER_ID_PRESSURE_MEASUREMENT, ESP_ZB_ZCL_ATTR_PRESSURE_MEASUREMENT_VALUE_ID, &sensor_val, 1);
         }
+        else if (strcmp(cluster, "co2") == 0)
+        {
+            float carbon = (float)(sensor_val) / 1000000.0f;
+
+            esp_zb_zcl_status_t state_co2 = esp_zb_zcl_set_attribute_val(param_ep, ESP_ZB_ZCL_CLUSTER_ID_CARBON_DIOXIDE_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_CARBON_DIOXIDE_MEASUREMENT_MEASURED_VALUE_ID, &carbon, false);
+            if (state_co2 != ESP_ZB_ZCL_STATUS_SUCCESS)
+            {
+                ESP_LOGE(TAG_send_data, "Setting co2 attribute failed!");
+            }
+
+            // reportAttribute(param_ep, ESP_ZB_ZCL_CLUSTER_ID_CARBON_DIOXIDE_MEASUREMENT, ESP_ZB_ZCL_ATTR_CARBON_DIOXIDE_MEASUREMENT_MEASURED_VALUE_ID, &sensor_val, 1);
+        }
         else if (strcmp(cluster, "BINARY") == 0)
         {
 

--- a/main/utils/send_data.c
+++ b/main/utils/send_data.c
@@ -46,197 +46,199 @@ void send_data(uint16_t sensor_val, int param_ep, char *cluster)
         cJSON_Delete(sensordata);
     }
     // ZIGBEE
-    if (sys_settings.zigbee.zigbee_conected == true && strcmp(cluster, "temperature") == 0)
+    if (sys_settings.zigbee.zigbee_conected == true)
     {
-
-        esp_zb_zcl_status_t state_tmp = esp_zb_zcl_set_attribute_val(param_ep, ESP_ZB_ZCL_CLUSTER_ID_TEMP_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_TEMP_MEASUREMENT_VALUE_ID, &sensor_val, false);
-        if (state_tmp != ESP_ZB_ZCL_STATUS_SUCCESS)
+        if (strcmp(cluster, "temperature") == 0)
         {
-            ESP_LOGE(TAG_send_data, "Setting temperature attribute failed!");
+            esp_zb_zcl_status_t state_tmp = esp_zb_zcl_set_attribute_val(param_ep, ESP_ZB_ZCL_CLUSTER_ID_TEMP_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_TEMP_MEASUREMENT_VALUE_ID, &sensor_val, false);
+            if (state_tmp != ESP_ZB_ZCL_STATUS_SUCCESS)
+            {
+                ESP_LOGE(TAG_send_data, "Setting temperature attribute failed!");
+            }
+
+            //    reportAttribute(param_ep, ESP_ZB_ZCL_CLUSTER_ID_TEMP_MEASUREMENT, ESP_ZB_ZCL_ATTR_TEMP_MEASUREMENT_VALUE_ID, &sensor_val, 1);
         }
-
-        //    reportAttribute(param_ep, ESP_ZB_ZCL_CLUSTER_ID_TEMP_MEASUREMENT, ESP_ZB_ZCL_ATTR_TEMP_MEASUREMENT_VALUE_ID, &sensor_val, 1);
-    }
-    else if (sys_settings.zigbee.zigbee_conected == true && strcmp(cluster, "humidity") == 0)
-    {
-
-        esp_zb_zcl_status_t state_hum = esp_zb_zcl_set_attribute_val(param_ep, ESP_ZB_ZCL_CLUSTER_ID_REL_HUMIDITY_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_REL_HUMIDITY_MEASUREMENT_VALUE_ID, &sensor_val, false);
-        if (state_hum != ESP_ZB_ZCL_STATUS_SUCCESS)
+        else if (strcmp(cluster, "humidity") == 0)
         {
-            ESP_LOGE(TAG_send_data, "Setting humidity attribute failed!");
+
+            esp_zb_zcl_status_t state_hum = esp_zb_zcl_set_attribute_val(param_ep, ESP_ZB_ZCL_CLUSTER_ID_REL_HUMIDITY_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_REL_HUMIDITY_MEASUREMENT_VALUE_ID, &sensor_val, false);
+            if (state_hum != ESP_ZB_ZCL_STATUS_SUCCESS)
+            {
+                ESP_LOGE(TAG_send_data, "Setting humidity attribute failed!");
+            }
+
+            //   reportAttribute(param_ep, ESP_ZB_ZCL_CLUSTER_ID_REL_HUMIDITY_MEASUREMENT, ESP_ZB_ZCL_ATTR_REL_HUMIDITY_MEASUREMENT_VALUE_ID, &sensor_val, 1);
         }
-
-        //   reportAttribute(param_ep, ESP_ZB_ZCL_CLUSTER_ID_REL_HUMIDITY_MEASUREMENT, ESP_ZB_ZCL_ATTR_REL_HUMIDITY_MEASUREMENT_VALUE_ID, &sensor_val, 1);
-    }
-    else if (sys_settings.zigbee.zigbee_conected == true && strcmp(cluster, "pressure") == 0)
-    {
-
-        esp_zb_zcl_status_t state_pres = esp_zb_zcl_set_attribute_val(param_ep, ESP_ZB_ZCL_CLUSTER_ID_PRESSURE_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_PRESSURE_MEASUREMENT_VALUE_ID, &sensor_val, false);
-        if (state_pres != ESP_ZB_ZCL_STATUS_SUCCESS)
+        else if (strcmp(cluster, "pressure") == 0)
         {
-            ESP_LOGE(TAG_send_data, "Setting pressure attribute failed!");
+
+            esp_zb_zcl_status_t state_pres = esp_zb_zcl_set_attribute_val(param_ep, ESP_ZB_ZCL_CLUSTER_ID_PRESSURE_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_PRESSURE_MEASUREMENT_VALUE_ID, &sensor_val, false);
+            if (state_pres != ESP_ZB_ZCL_STATUS_SUCCESS)
+            {
+                ESP_LOGE(TAG_send_data, "Setting pressure attribute failed!");
+            }
+
+            // reportAttribute(param_ep, ESP_ZB_ZCL_CLUSTER_ID_PRESSURE_MEASUREMENT, ESP_ZB_ZCL_ATTR_PRESSURE_MEASUREMENT_VALUE_ID, &sensor_val, 1);
         }
+        else if (strcmp(cluster, "BINARY") == 0)
+        {
 
-        // reportAttribute(param_ep, ESP_ZB_ZCL_CLUSTER_ID_PRESSURE_MEASUREMENT, ESP_ZB_ZCL_ATTR_PRESSURE_MEASUREMENT_VALUE_ID, &sensor_val, 1);
-    }
-    else if (sys_settings.zigbee.zigbee_conected == true && strcmp(cluster, "BINARY") == 0)
-    {
+            reportAttribute(param_ep, ESP_ZB_ZCL_CLUSTER_ID_BINARY_INPUT, ESP_ZB_ZCL_ATTR_BINARY_INPUT_PRESENT_VALUE_ID, &sensor_val, 1);
+        }
+        //----------------
+        else if (strcmp(cluster, "ZoneStatus") == 0)
+        {
 
-        reportAttribute(param_ep, ESP_ZB_ZCL_CLUSTER_ID_BINARY_INPUT, ESP_ZB_ZCL_ATTR_BINARY_INPUT_PRESENT_VALUE_ID, &sensor_val, 1);
-    }
-    //----------------
-    else if (sys_settings.zigbee.zigbee_conected == true && strcmp(cluster, "ZoneStatus") == 0)
-    {
+            esp_zb_zcl_ias_zone_status_change_notif_cmd_t cmd = {
+                .zcl_basic_cmd = {
+                    .dst_addr_u.addr_short = 0x0000,
+                    .dst_endpoint = param_ep,
+                    .src_endpoint = param_ep,
+                },
+                .address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT,
+                .zone_status = ESP_ZB_ZCL_IAS_ZONE_ZONE_STATUS_ALARM1 ? sensor_val : 0,
+                //    .zone_id = 0,
+                .delay = 0,
+            };
+            esp_zb_zcl_ias_zone_status_change_notif_cmd_req(&cmd);
+        }
+        else if (strcmp(cluster, "Motion") == 0)
+        {
 
-        esp_zb_zcl_ias_zone_status_change_notif_cmd_t cmd = {
-            .zcl_basic_cmd = {
-                .dst_addr_u.addr_short = 0x0000,
-                .dst_endpoint = param_ep,
-                .src_endpoint = param_ep,
-            },
-            .address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT,
-            .zone_status = ESP_ZB_ZCL_IAS_ZONE_ZONE_STATUS_ALARM1 ? sensor_val : 0,
-            //    .zone_id = 0,
-            .delay = 0,
-        };
-        esp_zb_zcl_ias_zone_status_change_notif_cmd_req(&cmd);
-    }
-    else if (sys_settings.zigbee.zigbee_conected == true && strcmp(cluster, "Motion") == 0)
-    {
+            esp_zb_zcl_ias_zone_status_change_notif_cmd_t cmd = {
+                .zcl_basic_cmd = {
+                    .dst_addr_u.addr_short = 0x0000,
+                    .dst_endpoint = param_ep,
+                    .src_endpoint = param_ep,
+                },
+                .address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT,
+                .zone_status = ESP_ZB_ZCL_IAS_ZONE_ZONE_STATUS_ALARM1 ? sensor_val : 0,
+                //    .zone_id = 0,
+                .delay = 0,
+            };
+            esp_zb_zcl_ias_zone_status_change_notif_cmd_req(&cmd);
+        }
+        else if (strcmp(cluster, "Contact") == 0)
+        {
 
-        esp_zb_zcl_ias_zone_status_change_notif_cmd_t cmd = {
-            .zcl_basic_cmd = {
-                .dst_addr_u.addr_short = 0x0000,
-                .dst_endpoint = param_ep,
-                .src_endpoint = param_ep,
-            },
-            .address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT,
-            .zone_status = ESP_ZB_ZCL_IAS_ZONE_ZONE_STATUS_ALARM1 ? sensor_val : 0,
-            //    .zone_id = 0,
-            .delay = 0,
-        };
-        esp_zb_zcl_ias_zone_status_change_notif_cmd_req(&cmd);
-    }
-    else if (sys_settings.zigbee.zigbee_conected == true && strcmp(cluster, "Contact") == 0)
-    {
+            esp_zb_zcl_ias_zone_status_change_notif_cmd_t cmd = {
+                .zcl_basic_cmd = {
+                    .dst_addr_u.addr_short = 0x0000,
+                    .dst_endpoint = param_ep,
+                    .src_endpoint = param_ep,
+                },
+                .address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT,
+                .zone_status = ESP_ZB_ZCL_IAS_ZONE_ZONE_STATUS_ALARM1 ? sensor_val : 0,
+                //    .zone_id = 0,
+                .delay = 0,
+            };
+            esp_zb_zcl_ias_zone_status_change_notif_cmd_req(&cmd);
+        }
+        else if (strcmp(cluster, "Door_Window") == 0)
+        {
 
-        esp_zb_zcl_ias_zone_status_change_notif_cmd_t cmd = {
-            .zcl_basic_cmd = {
-                .dst_addr_u.addr_short = 0x0000,
-                .dst_endpoint = param_ep,
-                .src_endpoint = param_ep,
-            },
-            .address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT,
-            .zone_status = ESP_ZB_ZCL_IAS_ZONE_ZONE_STATUS_ALARM1 ? sensor_val : 0,
-            //    .zone_id = 0,
-            .delay = 0,
-        };
-        esp_zb_zcl_ias_zone_status_change_notif_cmd_req(&cmd);
-    }
-    else if (sys_settings.zigbee.zigbee_conected == true && strcmp(cluster, "Door_Window") == 0)
-    {
+            esp_zb_zcl_ias_zone_status_change_notif_cmd_t cmd = {
+                .zcl_basic_cmd = {
+                    .dst_addr_u.addr_short = 0x0000,
+                    .dst_endpoint = param_ep,
+                    .src_endpoint = param_ep,
+                },
+                .address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT,
+                .zone_status = ESP_ZB_ZCL_IAS_ZONE_ZONE_STATUS_ALARM1 ? sensor_val : 0,
+                //    .zone_id = 0,
+                .delay = 0,
+            };
+            esp_zb_zcl_ias_zone_status_change_notif_cmd_req(&cmd);
+        }
+        else if (strcmp(cluster, "Fire") == 0)
+        {
 
-        esp_zb_zcl_ias_zone_status_change_notif_cmd_t cmd = {
-            .zcl_basic_cmd = {
-                .dst_addr_u.addr_short = 0x0000,
-                .dst_endpoint = param_ep,
-                .src_endpoint = param_ep,
-            },
-            .address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT,
-            .zone_status = ESP_ZB_ZCL_IAS_ZONE_ZONE_STATUS_ALARM1 ? sensor_val : 0,
-            //    .zone_id = 0,
-            .delay = 0,
-        };
-        esp_zb_zcl_ias_zone_status_change_notif_cmd_req(&cmd);
-    }
-    else if (sys_settings.zigbee.zigbee_conected == true && strcmp(cluster, "Fire") == 0)
-    {
+            esp_zb_zcl_ias_zone_status_change_notif_cmd_t cmd = {
+                .zcl_basic_cmd = {
+                    .dst_addr_u.addr_short = 0x0000,
+                    .dst_endpoint = param_ep,
+                    .src_endpoint = param_ep,
+                },
+                .address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT,
+                .zone_status = ESP_ZB_ZCL_IAS_ZONE_ZONE_STATUS_ALARM1 ? sensor_val : 0,
+                //    .zone_id = 0,
+                .delay = 0,
+            };
+            esp_zb_zcl_ias_zone_status_change_notif_cmd_req(&cmd);
+        }
+        else if (strcmp(cluster, "Occupancy") == 0)
+        {
 
-        esp_zb_zcl_ias_zone_status_change_notif_cmd_t cmd = {
-            .zcl_basic_cmd = {
-                .dst_addr_u.addr_short = 0x0000,
-                .dst_endpoint = param_ep,
-                .src_endpoint = param_ep,
-            },
-            .address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT,
-            .zone_status = ESP_ZB_ZCL_IAS_ZONE_ZONE_STATUS_ALARM1 ? sensor_val : 0,
-            //    .zone_id = 0,
-            .delay = 0,
-        };
-        esp_zb_zcl_ias_zone_status_change_notif_cmd_req(&cmd);
-    }
-    else if (sys_settings.zigbee.zigbee_conected == true && strcmp(cluster, "Occupancy") == 0)
-    {
+            esp_zb_zcl_ias_zone_status_change_notif_cmd_t cmd = {
+                .zcl_basic_cmd = {
+                    .dst_addr_u.addr_short = 0x0000,
+                    .dst_endpoint = param_ep,
+                    .src_endpoint = param_ep,
+                },
+                .address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT,
+                .zone_status = ESP_ZB_ZCL_IAS_ZONE_ZONE_STATUS_ALARM1 ? sensor_val : 0,
+                //    .zone_id = 0,
+                .delay = 0,
+            };
+            esp_zb_zcl_ias_zone_status_change_notif_cmd_req(&cmd);
+        }
+        else if (strcmp(cluster, "WaterLeak") == 0)
+        {
 
-        esp_zb_zcl_ias_zone_status_change_notif_cmd_t cmd = {
-            .zcl_basic_cmd = {
-                .dst_addr_u.addr_short = 0x0000,
-                .dst_endpoint = param_ep,
-                .src_endpoint = param_ep,
-            },
-            .address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT,
-            .zone_status = ESP_ZB_ZCL_IAS_ZONE_ZONE_STATUS_ALARM1 ? sensor_val : 0,
-            //    .zone_id = 0,
-            .delay = 0,
-        };
-        esp_zb_zcl_ias_zone_status_change_notif_cmd_req(&cmd);
-    }
-    else if (sys_settings.zigbee.zigbee_conected == true && strcmp(cluster, "WaterLeak") == 0)
-    {
+            esp_zb_zcl_ias_zone_status_change_notif_cmd_t cmd = {
+                .zcl_basic_cmd = {
+                    .dst_addr_u.addr_short = 0x0000,
+                    .dst_endpoint = param_ep,
+                    .src_endpoint = param_ep,
+                },
+                .address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT,
+                .zone_status = ESP_ZB_ZCL_IAS_ZONE_ZONE_STATUS_ALARM1 ? sensor_val : 0,
+                //    .zone_id = 0,
+                .delay = 0,
+            };
+            esp_zb_zcl_ias_zone_status_change_notif_cmd_req(&cmd);
+        }
+        else if (strcmp(cluster, "Carbon") == 0)
+        {
 
-        esp_zb_zcl_ias_zone_status_change_notif_cmd_t cmd = {
-            .zcl_basic_cmd = {
-                .dst_addr_u.addr_short = 0x0000,
-                .dst_endpoint = param_ep,
-                .src_endpoint = param_ep,
-            },
-            .address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT,
-            .zone_status = ESP_ZB_ZCL_IAS_ZONE_ZONE_STATUS_ALARM1 ? sensor_val : 0,
-            //    .zone_id = 0,
-            .delay = 0,
-        };
-        esp_zb_zcl_ias_zone_status_change_notif_cmd_req(&cmd);
-    }
-    else if (sys_settings.zigbee.zigbee_conected == true && strcmp(cluster, "Carbon") == 0)
-    {
+            esp_zb_zcl_ias_zone_status_change_notif_cmd_t cmd = {
+                .zcl_basic_cmd = {
+                    .dst_addr_u.addr_short = 0x0000,
+                    .dst_endpoint = param_ep,
+                    .src_endpoint = param_ep,
+                },
+                .address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT,
+                .zone_status = ESP_ZB_ZCL_IAS_ZONE_ZONE_STATUS_ALARM1 ? sensor_val : 0,
+                //    .zone_id = 0,
+                .delay = 0,
+            };
+            esp_zb_zcl_ias_zone_status_change_notif_cmd_req(&cmd);
+        }
+        else if (strcmp(cluster, "Remote_Control") == 0)
+        {
 
-        esp_zb_zcl_ias_zone_status_change_notif_cmd_t cmd = {
-            .zcl_basic_cmd = {
-                .dst_addr_u.addr_short = 0x0000,
-                .dst_endpoint = param_ep,
-                .src_endpoint = param_ep,
-            },
-            .address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT,
-            .zone_status = ESP_ZB_ZCL_IAS_ZONE_ZONE_STATUS_ALARM1 ? sensor_val : 0,
-            //    .zone_id = 0,
-            .delay = 0,
-        };
-        esp_zb_zcl_ias_zone_status_change_notif_cmd_req(&cmd);
-    }
-    else if (sys_settings.zigbee.zigbee_conected == true && strcmp(cluster, "Remote_Control") == 0)
-    {
-
-        esp_zb_zcl_ias_zone_status_change_notif_cmd_t cmd = {
-            .zcl_basic_cmd = {
-                .dst_addr_u.addr_short = 0x0000,
-                .dst_endpoint = param_ep,
-                .src_endpoint = param_ep,
-            },
-            .address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT,
-            .zone_status = ESP_ZB_ZCL_IAS_ZONE_ZONE_STATUS_ALARM1 ? sensor_val : 0,
-            //    .zone_id = 0,
-            .delay = 0,
-        };
-        esp_zb_zcl_ias_zone_status_change_notif_cmd_req(&cmd);
-    }
-    // swith
-    if (sys_settings.zigbee.zigbee_conected == true && strcmp(cluster, "switch") == 0)
-    {
-        reportAttribute(param_ep, ESP_ZB_ZCL_CLUSTER_ID_ON_OFF, ESP_ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID, &sensor_val, 1);
-    }
-    //   battery
-    if (sys_settings.zigbee.zigbee_conected == true && strcmp(cluster, "battery") == 0)
-    {
-        reportAttribute(param_ep, ESP_ZB_ZCL_CLUSTER_ID_POWER_CONFIG, ESP_ZB_ZCL_ATTR_POWER_CONFIG_BATTERY_PERCENTAGE_REMAINING_ID, &sensor_val, 1);
+            esp_zb_zcl_ias_zone_status_change_notif_cmd_t cmd = {
+                .zcl_basic_cmd = {
+                    .dst_addr_u.addr_short = 0x0000,
+                    .dst_endpoint = param_ep,
+                    .src_endpoint = param_ep,
+                },
+                .address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT,
+                .zone_status = ESP_ZB_ZCL_IAS_ZONE_ZONE_STATUS_ALARM1 ? sensor_val : 0,
+                //    .zone_id = 0,
+                .delay = 0,
+            };
+            esp_zb_zcl_ias_zone_status_change_notif_cmd_req(&cmd);
+        }
+        // swith
+        if (strcmp(cluster, "switch") == 0)
+        {
+            reportAttribute(param_ep, ESP_ZB_ZCL_CLUSTER_ID_ON_OFF, ESP_ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID, &sensor_val, 1);
+        }
+        //   battery
+        if (strcmp(cluster, "battery") == 0)
+        {
+            reportAttribute(param_ep, ESP_ZB_ZCL_CLUSTER_ID_POWER_CONFIG, ESP_ZB_ZCL_ATTR_POWER_CONFIG_BATTERY_PERCENTAGE_REMAINING_ID, &sensor_val, 1);
+        }
     }
 }

--- a/main/zigbee/zigbee_init.c
+++ b/main/zigbee/zigbee_init.c
@@ -800,6 +800,8 @@ static void esp_zb_task(void *pvParameters)
         cJSON *ep_ = cJSON_GetObjectItemCaseSensitive(item, "EP");
         cJSON *cluster_ = cJSON_GetObjectItemCaseSensitive(item, "cluster");
         cJSON *sensor_ = cJSON_GetObjectItemCaseSensitive(item, "sensor");
+        cJSON *clusters_ = cJSON_GetObjectItemCaseSensitive(item, "clusters");
+
         if (cJSON_IsString(sensor_) && cJSON_IsNumber(ep_) && cJSON_IsString(cluster_))
         {
             char *cluster = cluster_->valuestring;
@@ -807,7 +809,8 @@ static void esp_zb_task(void *pvParameters)
             char *sensor = sensor_->valuestring;
 
             esp_zb_cluster_list_t *esp_zb_cluster_list = get_existing_or_create_new_list(EP);
-            if (strcmp(sensor, "DHT") == 0 && strcmp(cluster, "all") == 0)
+
+            /*if (strcmp(sensor, "DHT") == 0 && strcmp(cluster, "all") == 0)
             {
                 createAttributes(esp_zb_cluster_list, "temperature", EP);
                 createAttributes(esp_zb_cluster_list, "humidity", EP);
@@ -828,10 +831,32 @@ static void esp_zb_task(void *pvParameters)
                 createAttributes(esp_zb_cluster_list, "humidity", EP);
                 createAttributes(esp_zb_cluster_list, "pressure", EP);
             }
+            else if (strcmp(sensor, "SiHT") == 0 && strcmp(cluster, "all") == 0)
+            {
+                createAttributes(esp_zb_cluster_list, "temperature", EP);
+                createAttributes(esp_zb_cluster_list, "humidity", EP);
+            }
+            else */
+
+            // if cluster set to all - create all clusters using json option clusters
+            if (strcmp(cluster, "all") == 0) {
+                cJSON *cluster_item;
+                cJSON_ArrayForEach(cluster_item, clusters_)
+                {
+                    if (cJSON_IsString(cluster_item) && strcmp(cluster_item->valuestring, "all") != 0)
+                    {
+                        createAttributes(esp_zb_cluster_list, cluster_item->valuestring, EP);
+                    }
+                }
+            }
+
+            // light cluster
             else if (strcmp(sensor, "led_light") == 0 && strcmp(cluster, "all") == 0)
             {
                 light_data_t *light = get_existing_or_create_new_light(EP);
             }
+
+            // default case - create only one cluster
             else
             {
                 createAttributes(esp_zb_cluster_list, cluster, EP);

--- a/main/zigbee/zigbee_init.c
+++ b/main/zigbee/zigbee_init.c
@@ -408,14 +408,27 @@ void createAttributes(esp_zb_cluster_list_t *esp_zb_cluster_list, char *cluster,
 {
     ESP_LOGW(TAG_zigbee, "Cluster: %s created. EP: %d", cluster, EP);
     uint16_t undefined_value;
+
     undefined_value = 0x8000;
 
-    if (strcmp(cluster, "illuminance") == 0)
+    float undefined_float = 0;
+    float float_one = 1;
+
+    if (strcmp(cluster, "co2") == 0)
+    {
+        esp_zb_attribute_list_t *esp_zb_carbon_dioxide_measurement_cluster = esp_zb_zcl_attr_list_create(ESP_ZB_ZCL_CLUSTER_ID_CARBON_DIOXIDE_MEASUREMENT);
+        esp_zb_carbon_dioxide_measurement_cluster_add_attr(esp_zb_carbon_dioxide_measurement_cluster, ESP_ZB_ZCL_ATTR_CARBON_DIOXIDE_MEASUREMENT_MEASURED_VALUE_ID, &undefined_float);
+        esp_zb_carbon_dioxide_measurement_cluster_add_attr(esp_zb_carbon_dioxide_measurement_cluster, ESP_ZB_ZCL_ATTR_CARBON_DIOXIDE_MEASUREMENT_MIN_MEASURED_VALUE_ID, &undefined_float); 
+        esp_zb_carbon_dioxide_measurement_cluster_add_attr(esp_zb_carbon_dioxide_measurement_cluster, ESP_ZB_ZCL_ATTR_CARBON_DIOXIDE_MEASUREMENT_MAX_MEASURED_VALUE_ID, &float_one); // https://github.com/espressif/esp-zigbee-sdk/issues/147#issuecomment-1820778678
+        esp_zb_cluster_list_add_carbon_dioxide_measurement_cluster(esp_zb_cluster_list, esp_zb_carbon_dioxide_measurement_cluster, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+    }
+
+    else if (strcmp(cluster, "illuminance") == 0)
     {
         esp_zb_attribute_list_t *esp_zb_illuminance_meas_cluster = esp_zb_zcl_attr_list_create(ESP_ZB_ZCL_CLUSTER_ID_ILLUMINANCE_MEASUREMENT);
-        esp_zb_illuminance_meas_cluster_add_attr(esp_zb_illuminance_meas_cluster, ESP_ZB_ZCL_ATTR_TEMP_MEASUREMENT_VALUE_ID, &undefined_value);
-        esp_zb_illuminance_meas_cluster_add_attr(esp_zb_illuminance_meas_cluster, ESP_ZB_ZCL_ATTR_TEMP_MEASUREMENT_MIN_VALUE_ID, &undefined_value);
-        esp_zb_illuminance_meas_cluster_add_attr(esp_zb_illuminance_meas_cluster, ESP_ZB_ZCL_ATTR_TEMP_MEASUREMENT_MAX_VALUE_ID, &undefined_value);
+        esp_zb_illuminance_meas_cluster_add_attr(esp_zb_illuminance_meas_cluster, ESP_ZB_ZCL_ATTR_ILLUMINANCE_MEASUREMENT_MEASURED_VALUE_ID, &undefined_value);
+        esp_zb_illuminance_meas_cluster_add_attr(esp_zb_illuminance_meas_cluster, ESP_ZB_ZCL_ATTR_ILLUMINANCE_MEASUREMENT_MIN_MEASURED_VALUE_ID, &undefined_value);
+        esp_zb_illuminance_meas_cluster_add_attr(esp_zb_illuminance_meas_cluster, ESP_ZB_ZCL_ATTR_ILLUMINANCE_MEASUREMENT_MAX_MEASURED_VALUE_ID, &undefined_value);
         esp_zb_cluster_list_add_illuminance_meas_cluster(esp_zb_cluster_list, esp_zb_illuminance_meas_cluster, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
     }
 
@@ -839,7 +852,8 @@ static void esp_zb_task(void *pvParameters)
             else */
 
             // if cluster set to all - create all clusters using json option clusters
-            if (strcmp(cluster, "all") == 0) {
+            if (strcmp(cluster, "all") == 0)
+            {
                 cJSON *cluster_item;
                 cJSON_ArrayForEach(cluster_item, clusters_)
                 {

--- a/spiffs_storage/element.json
+++ b/spiffs_storage/element.json
@@ -112,7 +112,7 @@
   },
   {
     "num": 8,
-    "name": "8. 🌡DS18b20 (temperature)",
+    "name": "8. 🌡 DS18b20 (temperature)",
     "sensor": "DS18b20",
     "id": "ds18b20",
     "int": 60,
@@ -126,10 +126,25 @@
     "EP": 1
   },
   {
+    "num": 9,
+    "name": "9. 🌡💧 Si70xx/HTU2xD/SHT2x (temperature humidity)",
+    "sensor": "SiHT",
+    "id": "siht",
+    "int": 60,
+    "pin_SDA": 6,
+    "pin_SCL": 7,
+    "clusters": [
+      "all",
+      "temperature",
+      "humidity"
+    ],
+    "EP": 1
+  },
+  {
     "header": "VIRTUAL"
   },
   {
-    "num": 9,
+    "num": 10,
     "name": "cluster_battary",
     "sensor": "battary",
     "id": "battary",
@@ -141,7 +156,7 @@
     "EP": 1
   },
   {
-    "num": 10,
+    "num": 11,
     "name": "deepsleep",
     "sensor": "deepsleep",
     "id": "deepsleep",

--- a/spiffs_storage/element.json
+++ b/spiffs_storage/element.json
@@ -131,12 +131,28 @@
     "sensor": "SiHT",
     "id": "siht",
     "int": 60,
-    "pin_SDA": 6,
     "pin_SCL": 7,
+    "pin_SDA": 6,
     "clusters": [
       "all",
       "temperature",
       "humidity"
+    ],
+    "EP": 1
+  },
+  {
+    "num": 10,
+    "name": "10. 🌪🌡💧 SCD4x CO2, temperature, humidity",
+    "sensor": "SCD4x",
+    "id": "scd4x",
+    "int": 60,
+    "pin_SCL": 7,
+    "pin_SDA": 6,
+    "clusters": [
+        "all",
+        "co2",
+        "temperature",
+        "humidity"
     ],
     "EP": 1
   },


### PR DESCRIPTION
[96f61c7](https://github.com/Live-Control-Project/MEEF/commit/973bc8ff5423194e88535e99f4fe17fdf0e9774a) 

Add support for Sensirion SCD4x CO2 sensors, including corresponding Zigbee cluster initialization and data publication, small fix on illuminance cluster.

[973bc8f](https://github.com/Live-Control-Project/MEEF/commit/96f61c7194163c280434c2229740115af4102e2d) 

Add support for Si70xx, HTU2xD, and SHT2x sensors (I2C temperature and humidity.
Fix reboot issue caused by incorrect configuration of BMP280 and AHT sensors.
Rework Zigbee cluster initialization and send data functions.

![Screenshot 2024-10-02 at 12 48 56 AM](https://github.com/user-attachments/assets/e284435c-48d6-4dc3-b277-421b564dbf2f)

![Screenshot 2024-10-02 at 12 46 47 AM](https://github.com/user-attachments/assets/43bc98e6-b8f6-4829-a20b-a54d3ffbb760)


